### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 # This is just a test since nginx supports HTTPS but does not enforce it
-homepage = "http://nginx.org/"
+homepage = "https://nginx.org/"
 
 # A site which (currently) does not support HTTPS at all
 documentation = "http://info.cern.ch/"
 
 # This one does redirect (and supports HSTS)
-repository = "http://github.com/Benjins"
+repository = "https://github.com/Benjins"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `/Cargo.toml`:
 - `http://nginx.org/` was updated. The HTTPS version exists, but HTTP version does not redirect to it
 - `http://github.com/Benjins` was updated. The HTTP version redirects to HTTPS, and HTTPS version has HSTS with preload

Some HTTP links could not be automatically converted to HTTPS:
In file `/Cargo.toml`:

 - `http://info.cern.ch/` was _not_ updated to HTTPS. The HTTPS version of the link seems to not work

